### PR TITLE
IG-5-jsh/formatter

### DIFF
--- a/src/main/java/kr/co/imguru/domain/member/controller/MemberRestController.java
+++ b/src/main/java/kr/co/imguru/domain/member/controller/MemberRestController.java
@@ -5,6 +5,8 @@ import kr.co.imguru.domain.member.dto.MemberCreateDto;
 import kr.co.imguru.domain.member.dto.MemberReadDto;
 import kr.co.imguru.domain.member.dto.MemberUpdateDto;
 import kr.co.imguru.domain.member.service.MemberService;
+import kr.co.imguru.global.model.ResponseFormat;
+import kr.co.imguru.global.model.ResponseStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -19,38 +21,44 @@ public class MemberRestController {
 
     // Create
     @PostMapping("/member")
-    public Long createMember(@RequestBody @Valid MemberCreateDto createDto) {
-        return memberService.createMember(createDto);
+    public ResponseFormat<Void> createMember(@RequestBody @Valid MemberCreateDto createDto) {
+        memberService.createMember(createDto);
+
+        return ResponseFormat.success(ResponseStatus.SUCCESS_OK);
     }
 
     @PostMapping("/member/guru")
-    public Long createGuruMember(@RequestBody @Valid MemberCreateDto createDto) {
-        return memberService.createGuruMember(createDto);
+    public ResponseFormat<Void> createGuruMember(@RequestBody @Valid MemberCreateDto createDto) {
+        memberService.createGuruMember(createDto);
+
+        return ResponseFormat.success(ResponseStatus.SUCCESS_OK);
     }
 
     // Read One
     @GetMapping("/member/{memberNickname}")
-    public MemberReadDto readMember(@PathVariable String memberNickname) {
-        return memberService.getMember(memberNickname);
+    public ResponseFormat<MemberReadDto> readMember(@PathVariable String memberNickname) {
+        return ResponseFormat.successWithData(ResponseStatus.SUCCESS_OK, memberService.getMember(memberNickname));
     }
 
     // Read All
     @GetMapping("/member/all")
-    public List<MemberReadDto> readAllMembers() {
-        return memberService.getAllMembers();
+    public ResponseFormat<List<MemberReadDto>> readAllMembers() {
+        return ResponseFormat.successWithData(ResponseStatus.SUCCESS_OK, memberService.getAllMembers());
     }
 
     // Update
     @PutMapping("/member/{memberNickname}")
-    public Long updateMember(@PathVariable String memberNickname,
+    public ResponseFormat<MemberReadDto> updateMember(@PathVariable String memberNickname,
                              @RequestBody @Valid MemberUpdateDto updateDto) {
-        return memberService.updateMember(memberNickname, updateDto);
+        return ResponseFormat.successWithData(ResponseStatus.SUCCESS_OK, memberService.updateMember(memberNickname, updateDto));
     }
 
     // Delete
     @DeleteMapping("/member/{memberNickname}")
-    public void deleteMember(@PathVariable String memberNickname) {
+    public ResponseFormat<Void> deleteMember(@PathVariable String memberNickname) {
         memberService.deleteMember(memberNickname);
+
+        return ResponseFormat.success(ResponseStatus.SUCCESS_OK);
     }
 
 }

--- a/src/main/java/kr/co/imguru/domain/member/service/MemberService.java
+++ b/src/main/java/kr/co/imguru/domain/member/service/MemberService.java
@@ -8,15 +8,15 @@ import java.util.List;
 
 public interface MemberService {
 
-    Long createMember(MemberCreateDto createDto);
+    void createMember(MemberCreateDto createDto);
 
-    Long createGuruMember(MemberCreateDto createDto);
+    void createGuruMember(MemberCreateDto createDto);
 
     MemberReadDto getMember(String memberNickname);
 
     List<MemberReadDto> getAllMembers();
 
-    Long updateMember(String memberNickname, MemberUpdateDto updateDto);
+    MemberReadDto updateMember(String memberNickname, MemberUpdateDto updateDto);
 
     void deleteMember(String memberNickname);
 

--- a/src/main/java/kr/co/imguru/domain/skill/controller/SkillRestController.java
+++ b/src/main/java/kr/co/imguru/domain/skill/controller/SkillRestController.java
@@ -5,6 +5,8 @@ import kr.co.imguru.domain.skill.dto.SkillCreateDto;
 import kr.co.imguru.domain.skill.dto.SkillReadDto;
 import kr.co.imguru.domain.skill.dto.SkillUpdateDto;
 import kr.co.imguru.domain.skill.service.SkillService;
+import kr.co.imguru.global.model.ResponseFormat;
+import kr.co.imguru.global.model.ResponseStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -18,28 +20,32 @@ public class SkillRestController {
     private final SkillService skillService;
 
     @PostMapping("/skill")
-    public Long createSkill(@RequestBody @Valid SkillCreateDto createDto) {
-        return skillService.createSkill(createDto);
+    public ResponseFormat<Void> createSkill(@RequestBody @Valid SkillCreateDto createDto) {
+        skillService.createSkill(createDto);
+
+        return ResponseFormat.success(ResponseStatus.SUCCESS_OK);
     }
 
     @GetMapping("/skill/{skillName}")
-    public SkillReadDto readSkill(@PathVariable String skillName) {
-        return skillService.getSkill(skillName);
+    public ResponseFormat<SkillReadDto> readSkill(@PathVariable String skillName) {
+        return ResponseFormat.successWithData(ResponseStatus.SUCCESS_OK, skillService.getSkill(skillName));
     }
 
     @GetMapping("/skill/all")
-    public List<SkillReadDto> readAllSkills() {
-        return skillService.getAllSkills();
+    public ResponseFormat<List<SkillReadDto>> readAllSkills() {
+        return ResponseFormat.successWithData(ResponseStatus.SUCCESS_OK, skillService.getAllSkills());
     }
 
     @PutMapping("/skill/{skillName}")
-    public Long updateSkill(@PathVariable String skillName,
+    public ResponseFormat<SkillReadDto> updateSkill(@PathVariable String skillName,
                             @RequestBody @Valid SkillUpdateDto updateDto) {
-        return skillService.updateSkill(skillName, updateDto);
+        return ResponseFormat.successWithData(ResponseStatus.SUCCESS_OK, skillService.updateSkill(skillName, updateDto));
     }
 
     @DeleteMapping("/skill/{skillName}")
-    public void deleteSkill(@PathVariable String skillName) {
+    public ResponseFormat<Void> deleteSkill(@PathVariable String skillName) {
         skillService.deleteSkill(skillName);
+
+        return ResponseFormat.success(ResponseStatus.SUCCESS_OK);
     }
 }

--- a/src/main/java/kr/co/imguru/domain/skill/service/SkillService.java
+++ b/src/main/java/kr/co/imguru/domain/skill/service/SkillService.java
@@ -8,13 +8,13 @@ import java.util.List;
 
 public interface SkillService {
 
-    Long createSkill(SkillCreateDto createDto);
+    void createSkill(SkillCreateDto createDto);
 
     SkillReadDto getSkill(String skillName);
 
     List<SkillReadDto> getAllSkills();
 
-    Long updateSkill(String skillName, SkillUpdateDto updateDto);
+    SkillReadDto updateSkill(String skillName, SkillUpdateDto updateDto);
 
     void deleteSkill(String skillName);
 }

--- a/src/main/java/kr/co/imguru/domain/skill/service/SkillServiceImpl.java
+++ b/src/main/java/kr/co/imguru/domain/skill/service/SkillServiceImpl.java
@@ -5,6 +5,9 @@ import kr.co.imguru.domain.skill.dto.SkillReadDto;
 import kr.co.imguru.domain.skill.dto.SkillUpdateDto;
 import kr.co.imguru.domain.skill.entity.Skill;
 import kr.co.imguru.domain.skill.repository.SkillRepository;
+import kr.co.imguru.global.exception.DuplicatedException;
+import kr.co.imguru.global.exception.NotFoundException;
+import kr.co.imguru.global.model.ResponseStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -18,14 +21,10 @@ public class SkillServiceImpl implements SkillService {
     private final SkillRepository skillRepository;
 
     @Override
-    public Long createSkill(SkillCreateDto createDto) {
+    public void createSkill(SkillCreateDto createDto) {
         isSkillName(createDto.getName());
 
-        Skill skill = toEntity(createDto);
-
-        skillRepository.save(skill);
-
-        return skill.getId();
+        skillRepository.save(toEntity(createDto));
     }
 
     @Override
@@ -45,7 +44,7 @@ public class SkillServiceImpl implements SkillService {
     }
 
     @Override
-    public Long updateSkill(String skillName, SkillUpdateDto updateDto) {
+    public SkillReadDto updateSkill(String skillName, SkillUpdateDto updateDto) {
         Optional<Skill> skill = skillRepository.findByNameAndIsDeleteFalse(skillName);
 
         isSkill(skill);
@@ -54,7 +53,7 @@ public class SkillServiceImpl implements SkillService {
 
         skillRepository.save(skill.get());
 
-        return skill.get().getId();
+        return toReadDto(skill.get());
     }
 
     @Override
@@ -70,13 +69,13 @@ public class SkillServiceImpl implements SkillService {
 
     private void isSkill(Optional<Skill> skill) {
         if (skill.isEmpty()) {
-            throw new RuntimeException();
+            throw new NotFoundException(ResponseStatus.FAIL_SKILL_NOT_FOUND);
         }
     }
 
     private void isSkillName(String skillName) {
         if (skillRepository.existsByNameAndIsDeleteFalse(skillName)) {
-            throw new RuntimeException();
+            throw new DuplicatedException(ResponseStatus.FAIL_SKILL_NAME_DUPLICATED);
         }
     }
 

--- a/src/main/java/kr/co/imguru/global/exception/BusinessLogicException.java
+++ b/src/main/java/kr/co/imguru/global/exception/BusinessLogicException.java
@@ -1,0 +1,18 @@
+package kr.co.imguru.global.exception;
+
+
+import kr.co.imguru.global.model.ResponseStatus;
+
+public class BusinessLogicException extends RuntimeException {
+
+    private ResponseStatus responseStatus;
+
+    public BusinessLogicException(ResponseStatus responseStatus) {
+        super(responseStatus.getMessage());
+        this.responseStatus = responseStatus;
+    }
+
+    public BusinessLogicException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/kr/co/imguru/global/exception/DuplicatedException.java
+++ b/src/main/java/kr/co/imguru/global/exception/DuplicatedException.java
@@ -1,0 +1,18 @@
+package kr.co.imguru.global.exception;
+
+
+import kr.co.imguru.global.model.ResponseStatus;
+
+/**
+ * 이미 존재하는 리소스를 생성하려 할 때 사용하는 예외
+ */
+public class DuplicatedException extends BusinessLogicException {
+
+    public DuplicatedException(ResponseStatus responseStatus) {
+        super(responseStatus);
+    }
+
+    public DuplicatedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/kr/co/imguru/global/exception/ForbiddenException.java
+++ b/src/main/java/kr/co/imguru/global/exception/ForbiddenException.java
@@ -1,0 +1,18 @@
+package kr.co.imguru.global.exception;
+
+
+import kr.co.imguru.global.model.ResponseStatus;
+
+/**
+ * 인증된 사용자가 권한이 없는 리소스에 접근하려 할 때 사용하는 예외
+ */
+public class ForbiddenException extends BusinessLogicException {
+
+    public ForbiddenException(ResponseStatus responseStatus) {
+        super(responseStatus);
+    }
+
+    public ForbiddenException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/kr/co/imguru/global/exception/IllegalArgumentException.java
+++ b/src/main/java/kr/co/imguru/global/exception/IllegalArgumentException.java
@@ -1,0 +1,14 @@
+package kr.co.imguru.global.exception;
+
+import kr.co.imguru.global.model.ResponseStatus;
+
+public class IllegalArgumentException extends BusinessLogicException{
+
+    public IllegalArgumentException(ResponseStatus responseStatus) {
+        super(responseStatus);
+    }
+
+    public IllegalArgumentException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/kr/co/imguru/global/exception/InvalidRequestException.java
+++ b/src/main/java/kr/co/imguru/global/exception/InvalidRequestException.java
@@ -1,0 +1,18 @@
+package kr.co.imguru.global.exception;
+
+
+import kr.co.imguru.global.model.ResponseStatus;
+
+/**
+ * 클라이언트의 요청이 잘못되었을 때 사용하는 예외
+ */
+public class InvalidRequestException extends BusinessLogicException {
+
+    public InvalidRequestException(ResponseStatus responseStatus) {
+        super(responseStatus);
+    }
+
+    public InvalidRequestException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/kr/co/imguru/global/exception/NotFoundException.java
+++ b/src/main/java/kr/co/imguru/global/exception/NotFoundException.java
@@ -1,0 +1,18 @@
+package kr.co.imguru.global.exception;
+
+
+import kr.co.imguru.global.model.ResponseStatus;
+
+/**
+ * 요청한 리소스가 존재하지 않을 때 사용하는 예외
+ */
+public class NotFoundException extends BusinessLogicException {
+
+    public NotFoundException(ResponseStatus responseStatus) {
+        super(responseStatus);
+    }
+
+    public NotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/kr/co/imguru/global/exception/UnauthorizedException.java
+++ b/src/main/java/kr/co/imguru/global/exception/UnauthorizedException.java
@@ -1,0 +1,18 @@
+package kr.co.imguru.global.exception;
+
+
+import kr.co.imguru.global.model.ResponseStatus;
+
+/**
+ * 인증되지 않은 사용자가 보호된 리소스에 접근하려 할 때 사용하는 예외
+ */
+public class UnauthorizedException extends BusinessLogicException {
+
+    public UnauthorizedException(ResponseStatus responseStatus) {
+        super(responseStatus);
+    }
+
+    public UnauthorizedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/kr/co/imguru/global/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/kr/co/imguru/global/exception/handler/GlobalExceptionHandler.java
@@ -1,0 +1,82 @@
+package kr.co.imguru.global.exception.handler;
+
+
+import kr.co.imguru.global.exception.DuplicatedException;
+import kr.co.imguru.global.exception.IllegalArgumentException;
+import kr.co.imguru.global.exception.NotFoundException;
+import kr.co.imguru.global.exception.UnauthorizedException;
+import kr.co.imguru.global.model.ResponseErrorFormat;
+import kr.co.imguru.global.model.ResponseStatus;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+
+//전역적으로 예외 처리를 담당하는 클래스
+@RestControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(DuplicatedException.class)
+    protected ResponseEntity<ResponseErrorFormat> handleDuplicatedException(DuplicatedException e) {
+        log.warn("-------HandleDuplicatedException-------", e);
+
+        ResponseErrorFormat responseErrorFormat = ResponseErrorFormat.builder()
+                .message(e.getMessage())
+                .statusCode(ResponseStatus.FAIL_BAD_REQUEST.getStatusCode())
+                .build();
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(responseErrorFormat);
+    }
+
+    @ExceptionHandler(NotFoundException.class)
+    protected ResponseEntity<ResponseErrorFormat> handleNotFoundException(NotFoundException e) {
+        log.warn("-------HandleNotFoundException-------", e);
+
+        ResponseErrorFormat responseErrorFormat = ResponseErrorFormat.builder()
+                .message(e.getMessage())
+                .statusCode(ResponseStatus.FAIL_NOT_FOUND.getStatusCode())
+                .build();
+
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(responseErrorFormat);
+    }
+
+    @ExceptionHandler(RuntimeException.class)
+    protected ResponseEntity<ResponseErrorFormat> handleRuntimeException(RuntimeException e) {
+        log.warn("-------HandleRuntimeException-------", e);
+
+        ResponseErrorFormat responseErrorFormat = ResponseErrorFormat.builder()
+                .message(e.getMessage())
+                .statusCode(ResponseStatus.FAIL_BAD_REQUEST.getStatusCode())
+                .build();
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(responseErrorFormat);
+    }
+
+    @ExceptionHandler(UnauthorizedException.class)
+    protected ResponseEntity<ResponseErrorFormat> handleAuthenticationException(UnauthorizedException e) {
+        log.warn("-------HandleAuthenticationException-------", e);
+
+        ResponseErrorFormat responseErrorFormat = ResponseErrorFormat.builder()
+                .message(e.getMessage())
+                .statusCode(ResponseStatus.FAIL_UNAUTHORIZED.getStatusCode())
+                .build();
+
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(responseErrorFormat);
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    protected ResponseEntity<ResponseErrorFormat> handleIllegalAccessException(IllegalArgumentException e) {
+        log.warn("-------HandleIllegalArgumentException-------", e);
+
+        ResponseErrorFormat responseErrorFormat = ResponseErrorFormat.builder()
+                .message(e.getMessage())
+                .statusCode(ResponseStatus.FAIL_ILLEGAL_ACCESS.getStatusCode())
+                .build();
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(responseErrorFormat);
+    }
+
+}

--- a/src/main/java/kr/co/imguru/global/model/ResponseErrorFormat.java
+++ b/src/main/java/kr/co/imguru/global/model/ResponseErrorFormat.java
@@ -1,0 +1,43 @@
+package kr.co.imguru.global.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.FieldError;
+
+import java.util.List;
+
+@Getter
+@Builder
+@RequiredArgsConstructor
+public class ResponseErrorFormat {
+
+    private final String message;
+
+    private final String statusName;
+
+    private final HttpStatus statusCode;
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private final List<ValidationException> validationExceptions;
+
+    @Getter
+    @Builder
+    @RequiredArgsConstructor
+    public static class ValidationException {
+        private final String message;
+
+        private final String field;
+
+        public static ValidationException of(final FieldError fieldError) {
+
+            return ValidationException.builder()
+                    .message(fieldError.getDefaultMessage())
+                    .field(fieldError.getField())
+                    .build();
+
+        }
+    }
+}

--- a/src/main/java/kr/co/imguru/global/model/ResponseFormat.java
+++ b/src/main/java/kr/co/imguru/global/model/ResponseFormat.java
@@ -1,0 +1,43 @@
+package kr.co.imguru.global.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+import java.util.Optional;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ResponseFormat<T> {
+
+    private Optional<T> data;
+
+    private String message;
+
+    private HttpStatus statusCode;
+
+    // Success - If the ResponseStatus is declared + return Only Message
+    public static <T> ResponseFormat<T> success(ResponseStatus responseStatus) {
+        return ResponseFormat.<T>builder()
+                .data(Optional.empty())
+                .message(responseStatus.getMessage())
+                .statusCode(responseStatus.getStatusCode())
+                .build();
+    }
+
+
+    // Success - If the ResponseStatus is declared + return Message And Data
+    public static <T> ResponseFormat<T> successWithData(ResponseStatus responseStatus,
+                                                        T data) {
+        return ResponseFormat.<T>builder()
+                .data(Optional.ofNullable(data))
+                .message(responseStatus.getMessage())
+                .statusCode(responseStatus.getStatusCode())
+                .build();
+    }
+
+}

--- a/src/main/java/kr/co/imguru/global/model/ResponseStatus.java
+++ b/src/main/java/kr/co/imguru/global/model/ResponseStatus.java
@@ -1,0 +1,68 @@
+package kr.co.imguru.global.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public enum ResponseStatus {
+
+    // Success Status
+    SUCCESS_OK("요청이 성공적으로 처리되었습니다.", HttpStatus.OK),
+    SUCCESS_CREATE("요청이 성공적으로 처리되어 새로운 리소스가 생성되었습니다.", HttpStatus.CREATED),
+    SUCCESS_ACCEPTED("요청이 성공적으로 처리되었지만, 결과가 아직 완료되지 않았습니다.", HttpStatus.ACCEPTED),
+    SUCCESS_NO_CONTENT("요청이 성공적으로 처리되었지만, 응답 데이터가 없습니다.", HttpStatus.NO_CONTENT),
+
+    // Failed Status
+    FAIL_BAD_REQUEST("클라이언트의 요청이 잘못되었습니다.", HttpStatus.BAD_REQUEST),
+    FAIL_UNAUTHORIZED("클라이언트가 인증되지 않았습니다.", HttpStatus.UNAUTHORIZED),
+    FAIL_FORBIDDEN("클라이언트가 요청한 리소스에 접근할 권한이 없습니다.", HttpStatus.FORBIDDEN),
+    FAIL_NOT_FOUND("클라이언트가 요청한 리소스를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    FAIL_METHOD_NOT_ALLOWED("클라이언트가 요청한 HTTP 메소드가 허용되지 않았습니다.", HttpStatus.METHOD_NOT_ALLOWED),
+    FAIL_INVALID_PARAMETER("파라미터 값이 유효하지 않습니다.", HttpStatus.BAD_REQUEST),
+    FAIL_ILLEGAL_ACCESS("파라미터 값이 유효하지 않습니다.", HttpStatus.BAD_REQUEST),
+
+    // Member Failed Status
+    FAIL_MEMBER_NOT_FOUND("클라이언트가 요청한 소유자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    FAIL_MEMBER_GENDER_NOT_FOUND("클라이언트가 요청한 소유자의 성별을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    FAIL_MEMBER_ROLE_NOT_FOUND("클라이언트가 요청한 소유자의 권한을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    FAIL_MEMBER_EMAIL_DUPLICATED("클라이언트가 요청한 이메일이 중복되었습니다.", HttpStatus.BAD_REQUEST),
+    FAIL_MEMBER_TELEPHONE_DUPLICATED("클라이언트가 요청한 전화번호가 중복되었습니다.", HttpStatus.BAD_REQUEST),
+    FAIL_MEMBER_NICKNAME_DUPLICATED("클라이언트가 요청한 닉네임이 중복되었습니다.", HttpStatus.BAD_REQUEST),
+    FAIL_MEMBER_PASSWORD_NOT_MATCHED("클라이언트가 입력한 비밀번호가 소유자의 비밀번호와 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
+
+    // Post
+    FAIL_POST_NOT_FOUND("클라이언트가 요청한 게시글을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    FAIL_POST_CATEGORY_NOT_FOUND("클라이언트가 요청한 게시글의 카테고리를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    FAIL_POST_LIKE_MEMBER_DUPLICATED("이미 좋아요를 누른 게시물입니다.", HttpStatus.BAD_REQUEST),
+
+    // Reply
+    FAIL_REPLY_NOT_FOUND("클라이언트가 요청한 댓글을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    FAIL_REPLY_LIKE_MEMBER_DUPLICATED("이미 좋아요를 누른 댓글입니다.", HttpStatus.BAD_REQUEST),
+
+    // Report
+    FAIL_REPORT_NOT_FOUND("클라이언트가 요청한 신고를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    FAIL_REPORT_DUPLICATED("클라이언트가 요청한 신고는 이미 접수되었습니다. 중복 신고는 불가능합나디.", HttpStatus.BAD_REQUEST),
+    FAIL_REPORT_CATEGORY_NOT_FOUND("클라이언트가 요청한 신고의 카테고리를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+
+    // Skill
+    FAIL_SKILL_NOT_FOUND("클라이언트가 요청한 스킬을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    FAIL_SKILL_NAME_DUPLICATED("클라이언트가 요청한 스킬이 중복되었습니다.", HttpStatus.BAD_REQUEST),
+    FAIL_SKILL_OUT_OF_BOUND("클라이언트가 요청한 스킬의 갯수가 초과되었습니다.", HttpStatus.BAD_REQUEST),
+
+    // Login Failed Status
+    FAIL_LOGIN_NOT_SUCCESS("로그인이 되지 않았습니다. 재시도 해주세요.", HttpStatus.BAD_REQUEST),
+
+    // Token Failed Status
+    FAIL_TOKEN_NOT_FOUND("클라이언트가 요청한 토큰 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+
+    FAIL_REFRESHTOKEN_NOT_FOUND("클라이언트가 요청한 RefreshToken을 찾을 수 없습니다.(만료)", HttpStatus.NOT_FOUND);
+
+
+    private String message;
+
+    private HttpStatus statusCode;
+}


### PR DESCRIPTION
1. ResponseEntity와 HttpStatus를 사용해주지 않고 custom한 ResponseFormat, ResponseStatus를 생성하여 사용
2. Custom 해준 응답 코드와 응답 포맷에 맞는 메세지를 출력해주기 위해서 기존에 사용하던 Exception과 동일한 명칭으로 class 생성 후 재정의
3. 기존에 만들었던 Member와 Skill 에서 create 시에 반환 값을 void로, update 시 readDto로 수정
4. 기존에 만들었던 Controller에서의 return 을 ResponseFormat으로 변환
5. Exception의 경우도 custom한 상태 코드를 만들어서 예외에 맞는 상태 코드가 출력되도록 수정