### PR TITLE
IG-11-jsh/report - CRUD

### DIFF
--- a/src/main/java/kr/co/imguru/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/kr/co/imguru/domain/post/service/PostServiceImpl.java
@@ -118,7 +118,7 @@ public class PostServiceImpl implements PostService {
         try {
             PostCategory.valueOf(categoryName);
         } catch (IllegalArgumentException e) {
-            throw new IllegalArgumentException(ResponseStatus.FAIL_ILLEGAL_ACCESS);
+            throw new IllegalArgumentException(ResponseStatus.FAIL_POST_CATEGORY_NOT_FOUND);
         }
     }
 

--- a/src/main/java/kr/co/imguru/domain/report/controller/ReportPostRestController.java
+++ b/src/main/java/kr/co/imguru/domain/report/controller/ReportPostRestController.java
@@ -1,0 +1,46 @@
+package kr.co.imguru.domain.report.controller;
+
+import jakarta.validation.Valid;
+import kr.co.imguru.domain.report.dto.ReportPostCreateDto;
+import kr.co.imguru.domain.report.dto.ReportPostReadDto;
+import kr.co.imguru.domain.report.service.ReportPostService;
+import kr.co.imguru.global.model.ResponseFormat;
+import kr.co.imguru.global.model.ResponseStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class ReportPostRestController {
+
+    private final ReportPostService reportPostService;
+
+    @PostMapping("/reportPost")
+    public ResponseFormat<Void> createReportPost(@RequestBody @Valid ReportPostCreateDto createDto) {
+        reportPostService.createReportPost(createDto);
+        return ResponseFormat.success(ResponseStatus.SUCCESS_OK);
+    }
+
+    @GetMapping("/reportPost/{reportPostId}")
+    public ResponseFormat<ReportPostReadDto> readReportPost(@PathVariable Long reportPostId) {
+        return ResponseFormat.successWithData(ResponseStatus.SUCCESS_OK, reportPostService.getReportPost(reportPostId));
+    }
+
+    @GetMapping("/reportPost/all")
+    public ResponseFormat<List<ReportPostReadDto>> readAllReportPosts() {
+        return ResponseFormat.successWithData(ResponseStatus.SUCCESS_OK, reportPostService.getAllReportPosts());
+    }
+
+    @GetMapping("/reportPost/post/{postId}")
+    public ResponseFormat<List<ReportPostReadDto>> readReportPostsByPost(@PathVariable Long postId) {
+        return ResponseFormat.successWithData(ResponseStatus.SUCCESS_OK, reportPostService.getReportPostByPost(postId));
+    }
+
+    @GetMapping("/reportPost/member/{memberNickname}")
+    public ResponseFormat<List<ReportPostReadDto>> readReportPostsByMember(@PathVariable String memberNickname) {
+        return ResponseFormat.successWithData(ResponseStatus.SUCCESS_OK, reportPostService.getReportPostByMember(memberNickname));
+    }
+}

--- a/src/main/java/kr/co/imguru/domain/report/controller/ReportReplyRestController.java
+++ b/src/main/java/kr/co/imguru/domain/report/controller/ReportReplyRestController.java
@@ -1,0 +1,47 @@
+package kr.co.imguru.domain.report.controller;
+
+import jakarta.validation.Valid;
+import kr.co.imguru.domain.report.dto.ReportReplyCreateDto;
+import kr.co.imguru.domain.report.dto.ReportReplyReadDto;
+import kr.co.imguru.domain.report.service.ReportReplyService;
+import kr.co.imguru.global.model.ResponseFormat;
+import kr.co.imguru.global.model.ResponseStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class ReportReplyRestController {
+
+    private final ReportReplyService reportReplyService;
+
+    @PostMapping("/reportReply")
+    public ResponseFormat<Void> createReportReply(@RequestBody @Valid ReportReplyCreateDto createDto) {
+        reportReplyService.createReportReply(createDto);
+        return ResponseFormat.success(ResponseStatus.SUCCESS_OK);
+    }
+
+    @GetMapping("/reportReply/{reportReplyId}")
+    public ResponseFormat<ReportReplyReadDto> readReportReply(@PathVariable Long reportReplyId) {
+        return ResponseFormat.successWithData(ResponseStatus.SUCCESS_OK, reportReplyService.getReportReply(reportReplyId));
+    }
+
+    @GetMapping("/reportReply/all")
+    public ResponseFormat<List<ReportReplyReadDto>> readAllReportReplies() {
+        return ResponseFormat.successWithData(ResponseStatus.SUCCESS_OK, reportReplyService.getAllReportReplies());
+    }
+
+    @GetMapping("/reportReply/reply/{replyId}")
+    public ResponseFormat<List<ReportReplyReadDto>> readReportRepliesByReply(@PathVariable Long replyId) {
+        return ResponseFormat.successWithData(ResponseStatus.SUCCESS_OK, reportReplyService.getReportRepliesByReply(replyId));
+    }
+
+    @GetMapping("/reportReply/member/{memberNickname}")
+    public ResponseFormat<List<ReportReplyReadDto>> readReportRepliesByMember(@PathVariable String memberNickname) {
+        return ResponseFormat.successWithData(ResponseStatus.SUCCESS_OK, reportReplyService.getReportRepliesByMember(memberNickname));
+    }
+
+}

--- a/src/main/java/kr/co/imguru/domain/report/dto/ReportPostCreateDto.java
+++ b/src/main/java/kr/co/imguru/domain/report/dto/ReportPostCreateDto.java
@@ -1,0 +1,22 @@
+package kr.co.imguru.domain.report.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ReportPostCreateDto {
+
+    private String memberNickname;
+
+    private Long postId;
+
+    private String categoryName;
+
+    private String description;
+
+}

--- a/src/main/java/kr/co/imguru/domain/report/dto/ReportPostReadDto.java
+++ b/src/main/java/kr/co/imguru/domain/report/dto/ReportPostReadDto.java
@@ -1,0 +1,29 @@
+package kr.co.imguru.domain.report.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ReportPostReadDto {
+
+    private Long reportPostId;
+
+    private String memberNickname;
+
+    private Long postId;
+
+    private String postTitle;
+
+    private String postContent;
+
+    private String postWriter;
+
+    private String categoryName;
+
+    private String description;
+}

--- a/src/main/java/kr/co/imguru/domain/report/dto/ReportReplyCreateDto.java
+++ b/src/main/java/kr/co/imguru/domain/report/dto/ReportReplyCreateDto.java
@@ -1,0 +1,22 @@
+package kr.co.imguru.domain.report.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ReportReplyCreateDto {
+
+    private String memberNickname;
+
+    private Long replyId;
+
+    private String categoryName;
+
+    private String description;
+
+}

--- a/src/main/java/kr/co/imguru/domain/report/dto/ReportReplyReadDto.java
+++ b/src/main/java/kr/co/imguru/domain/report/dto/ReportReplyReadDto.java
@@ -1,0 +1,27 @@
+package kr.co.imguru.domain.report.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ReportReplyReadDto {
+
+    private Long reportReplyId;
+
+    private String memberNickname;
+
+    private Long replyId;
+
+    private String replyContent;
+
+    private String replyWriter;
+
+    private String categoryName;
+
+    private String description;
+}

--- a/src/main/java/kr/co/imguru/domain/report/entity/ReportPost.java
+++ b/src/main/java/kr/co/imguru/domain/report/entity/ReportPost.java
@@ -7,6 +7,7 @@ import kr.co.imguru.domain.post.entity.Post;
 import kr.co.imguru.global.common.BaseEntity;
 import kr.co.imguru.global.common.ReportCategory;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -39,6 +40,7 @@ public class ReportPost extends BaseEntity {
     @Column(nullable = false, name="is_accept")
     private boolean isAccept = false;
 
+    @Builder
     public ReportPost(Member member,
                       Post post,
                       ReportCategory reportCategory,

--- a/src/main/java/kr/co/imguru/domain/report/entity/ReportReply.java
+++ b/src/main/java/kr/co/imguru/domain/report/entity/ReportReply.java
@@ -8,6 +8,7 @@ import kr.co.imguru.domain.reply.entity.Reply;
 import kr.co.imguru.global.common.BaseEntity;
 import kr.co.imguru.global.common.ReportCategory;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -40,6 +41,7 @@ public class ReportReply extends BaseEntity {
     @Column(nullable = false, name="is_accept")
     private boolean isAccept = false;
 
+    @Builder
     public ReportReply(Member member,
                        Reply reply,
                        ReportCategory reportCategory,

--- a/src/main/java/kr/co/imguru/domain/report/repository/ReportPostRepository.java
+++ b/src/main/java/kr/co/imguru/domain/report/repository/ReportPostRepository.java
@@ -1,0 +1,17 @@
+package kr.co.imguru.domain.report.repository;
+
+import kr.co.imguru.domain.report.entity.ReportPost;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ReportPostRepository extends JpaRepository<ReportPost, Long> {
+
+    boolean existsByPost_IdAndMember_NicknameAndIsDeleteFalse(Long postId, String memberNickname);
+
+    List<ReportPost> findAllByPost_Id(Long postId);
+
+    List<ReportPost> findAllByMember_Nickname(String memberNickname);
+}

--- a/src/main/java/kr/co/imguru/domain/report/repository/ReportReplyRepository.java
+++ b/src/main/java/kr/co/imguru/domain/report/repository/ReportReplyRepository.java
@@ -1,0 +1,17 @@
+package kr.co.imguru.domain.report.repository;
+
+import kr.co.imguru.domain.report.entity.ReportReply;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ReportReplyRepository extends JpaRepository<ReportReply, Long> {
+
+    boolean existsByReply_IdAndMember_NicknameAndIsDeleteFalse(Long replyId, String memberNickname);
+
+    List<ReportReply> findAllByReply_Id(Long replyId);
+
+    List<ReportReply> findAllByMember_Nickname(String memberNickname);
+}

--- a/src/main/java/kr/co/imguru/domain/report/service/ReportPostService.java
+++ b/src/main/java/kr/co/imguru/domain/report/service/ReportPostService.java
@@ -1,0 +1,20 @@
+package kr.co.imguru.domain.report.service;
+
+import kr.co.imguru.domain.report.dto.ReportPostCreateDto;
+import kr.co.imguru.domain.report.dto.ReportPostReadDto;
+
+import java.util.List;
+
+public interface ReportPostService {
+
+    void createReportPost(ReportPostCreateDto createDto);
+
+    ReportPostReadDto getReportPost(Long reportPostId);
+
+    List<ReportPostReadDto> getReportPostByPost(Long postId);   // 게시글 신고 목록
+
+    List<ReportPostReadDto> getReportPostByMember(String memberNickname);   // 회원이 신고한 신고 목록
+
+    List<ReportPostReadDto> getAllReportPosts();
+
+}

--- a/src/main/java/kr/co/imguru/domain/report/service/ReportPostServiceImpl.java
+++ b/src/main/java/kr/co/imguru/domain/report/service/ReportPostServiceImpl.java
@@ -1,0 +1,135 @@
+package kr.co.imguru.domain.report.service;
+
+import kr.co.imguru.domain.member.entity.Member;
+import kr.co.imguru.domain.member.repository.MemberRepository;
+import kr.co.imguru.domain.post.entity.Post;
+import kr.co.imguru.domain.post.repository.PostRepository;
+import kr.co.imguru.domain.report.dto.ReportPostCreateDto;
+import kr.co.imguru.domain.report.dto.ReportPostReadDto;
+import kr.co.imguru.domain.report.entity.ReportPost;
+import kr.co.imguru.domain.report.repository.ReportPostRepository;
+import kr.co.imguru.global.common.ReportCategory;
+import kr.co.imguru.global.exception.DuplicatedException;
+import kr.co.imguru.global.exception.IllegalArgumentException;
+import kr.co.imguru.global.exception.NotFoundException;
+import kr.co.imguru.global.model.ResponseStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class ReportPostServiceImpl implements ReportPostService {
+
+    private final ReportPostRepository reportPostRepository;
+
+    private final MemberRepository memberRepository;
+
+    private final PostRepository postRepository;
+
+    @Override
+    public void createReportPost(ReportPostCreateDto createDto) {
+        Optional<Member> member = memberRepository.findByNicknameAndIsDeleteFalse(createDto.getMemberNickname());
+        isMember(member);
+
+        Optional<Post> post = postRepository.findByIdAndIsDeleteFalse(createDto.getPostId());
+        isPost(post);
+
+        isReportCategory(createDto.getCategoryName());
+
+        isReportPostDuplicated(createDto.getPostId(), createDto.getMemberNickname());
+
+        reportPostRepository.save(toEntity(createDto));
+    }
+
+    @Override
+    public ReportPostReadDto getReportPost(Long reportPostId) {
+        Optional<ReportPost> reportPost = reportPostRepository.findById(reportPostId);
+
+        isReportPost(reportPost);
+
+        return toReadDto(reportPost.get());
+    }
+
+    @Override
+    public List<ReportPostReadDto> getReportPostByPost(Long postId) {
+        return reportPostRepository.findAllByPost_Id(postId)
+                .stream()
+                .map(this::toReadDto)
+                .toList();
+    }
+
+    @Override
+    public List<ReportPostReadDto> getReportPostByMember(String memberNickname) {
+        return reportPostRepository.findAllByMember_Nickname(memberNickname)
+                .stream()
+                .map(this::toReadDto)
+                .toList();
+    }
+
+    @Override
+    public List<ReportPostReadDto> getAllReportPosts() {
+        return reportPostRepository.findAll()
+                .stream()
+                .map(this::toReadDto)
+                .toList();
+    }
+
+    private void isMember(Optional<Member> member) {
+        if (member.isEmpty()) {
+            throw new NotFoundException(ResponseStatus.FAIL_MEMBER_NOT_FOUND);
+        }
+    }
+
+    private void isPost(Optional<Post> post) {
+        if (post.isEmpty()) {
+            throw new NotFoundException(ResponseStatus.FAIL_POST_NOT_FOUND);
+        }
+    }
+
+    private void isReportCategory(String categoryName) {
+        try {
+            ReportCategory.valueOf(categoryName);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(ResponseStatus.FAIL_REPORT_CATEGORY_NOT_FOUND);
+        }
+    }
+
+    private void isReportPost(Optional<ReportPost> reportPost) {
+        if (reportPost.isEmpty()) {
+            throw new NotFoundException(ResponseStatus.FAIL_REPORT_POST_NOT_FOUND);
+        }
+    }
+
+    private void isReportPostDuplicated(Long postId, String memberNickname) {
+        if (reportPostRepository.existsByPost_IdAndMember_NicknameAndIsDeleteFalse(postId, memberNickname)) {
+            throw new DuplicatedException(ResponseStatus.FAIL_REPORT_DUPLICATED);
+        }
+    }
+
+    private ReportPost toEntity(ReportPostCreateDto dto) {
+        return ReportPost.builder()
+                .member(memberRepository.findByNicknameAndIsDeleteFalse(dto.getMemberNickname()).get())
+                .post(postRepository.findByIdAndIsDeleteFalse(dto.getPostId()).get())
+                .reportCategory(ReportCategory.valueOf(dto.getCategoryName()))
+                .description(dto.getDescription())
+                .isAccept(false)
+                .build();
+    }
+
+    private ReportPostReadDto toReadDto(ReportPost reportPost) {
+        return ReportPostReadDto.builder()
+                .reportPostId(reportPost.getId())
+                .memberNickname(reportPost.getMember().getNickname())
+                .postId(reportPost.getPost().getId())
+                .postTitle(reportPost.getPost().getTitle())
+                .postContent(reportPost.getPost().getContent())
+                .postWriter(reportPost.getPost().getMember().getNickname())
+                .categoryName(String.valueOf(reportPost.getReportCategory()))
+                .description(reportPost.getDescription())
+                .build();
+    }
+
+}

--- a/src/main/java/kr/co/imguru/domain/report/service/ReportReplyService.java
+++ b/src/main/java/kr/co/imguru/domain/report/service/ReportReplyService.java
@@ -1,0 +1,19 @@
+package kr.co.imguru.domain.report.service;
+
+import kr.co.imguru.domain.report.dto.ReportReplyCreateDto;
+import kr.co.imguru.domain.report.dto.ReportReplyReadDto;
+
+import java.util.List;
+
+public interface ReportReplyService {
+
+    void createReportReply(ReportReplyCreateDto createDto);
+
+    ReportReplyReadDto getReportReply(Long reportReplyId);
+
+    List<ReportReplyReadDto> getReportRepliesByReply(Long replyId);   // 댓글 신고 목록
+
+    List<ReportReplyReadDto> getReportRepliesByMember(String memberNickname);   // 회원이 신고한 신고 목록
+
+    List<ReportReplyReadDto> getAllReportReplies();
+}

--- a/src/main/java/kr/co/imguru/domain/report/service/ReportReplyServiceImpl.java
+++ b/src/main/java/kr/co/imguru/domain/report/service/ReportReplyServiceImpl.java
@@ -1,0 +1,133 @@
+package kr.co.imguru.domain.report.service;
+
+import kr.co.imguru.domain.member.entity.Member;
+import kr.co.imguru.domain.member.repository.MemberRepository;
+import kr.co.imguru.domain.reply.entity.Reply;
+import kr.co.imguru.domain.reply.repository.ReplyRepository;
+import kr.co.imguru.domain.report.dto.ReportReplyCreateDto;
+import kr.co.imguru.domain.report.dto.ReportReplyReadDto;
+import kr.co.imguru.domain.report.entity.ReportReply;
+import kr.co.imguru.domain.report.repository.ReportReplyRepository;
+import kr.co.imguru.global.common.ReportCategory;
+import kr.co.imguru.global.exception.DuplicatedException;
+import kr.co.imguru.global.exception.IllegalArgumentException;
+import kr.co.imguru.global.exception.NotFoundException;
+import kr.co.imguru.global.model.ResponseStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class ReportReplyServiceImpl implements ReportReplyService {
+
+    private final ReportReplyRepository reportReplyRepository;
+
+    private final MemberRepository memberRepository;
+
+    private final ReplyRepository replyRepository;
+
+    @Override
+    public void createReportReply(ReportReplyCreateDto createDto) {
+        Optional<Member> member = memberRepository.findByNicknameAndIsDeleteFalse(createDto.getMemberNickname());
+        isMember(member);
+
+        Optional<Reply> reply = replyRepository.findByIdAndIsDeleteFalse(createDto.getReplyId());
+        isReply(reply);
+
+        isReportCategory(createDto.getCategoryName());
+
+        isReportReplyDuplicated(createDto.getReplyId(), createDto.getMemberNickname());
+
+        reportReplyRepository.save(toEntity(createDto));
+    }
+
+    @Override
+    public ReportReplyReadDto getReportReply(Long reportReplyId) {
+        Optional<ReportReply> reportReply = reportReplyRepository.findById(reportReplyId);
+
+        isReportReply(reportReply);
+
+        return toReadDto(reportReply.get());
+    }
+
+    @Override
+    public List<ReportReplyReadDto> getReportRepliesByReply(Long replyId) {
+        return reportReplyRepository.findAllByReply_Id(replyId)
+                .stream()
+                .map(this::toReadDto)
+                .toList();
+    }
+
+    @Override
+    public List<ReportReplyReadDto> getReportRepliesByMember(String memberNickname) {
+        return reportReplyRepository.findAllByMember_Nickname(memberNickname)
+                .stream()
+                .map(this::toReadDto)
+                .toList();
+    }
+
+    @Override
+    public List<ReportReplyReadDto> getAllReportReplies() {
+        return reportReplyRepository.findAll()
+                .stream()
+                .map(this::toReadDto)
+                .toList();
+    }
+
+    private void isMember(Optional<Member> member) {
+        if (member.isEmpty()) {
+            throw new NotFoundException(ResponseStatus.FAIL_MEMBER_NOT_FOUND);
+        }
+    }
+
+    private void isReply(Optional<Reply> reply) {
+        if (reply.isEmpty()) {
+            throw new NotFoundException(ResponseStatus.FAIL_REPLY_NOT_FOUND);
+        }
+    }
+
+    private void isReportCategory(String categoryName) {
+        try {
+            ReportCategory.valueOf(categoryName);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(ResponseStatus.FAIL_REPORT_CATEGORY_NOT_FOUND);
+        }
+    }
+
+    private void isReportReply(Optional<ReportReply> reportReply) {
+        if (reportReply.isEmpty()) {
+            throw new NotFoundException(ResponseStatus.FAIL_REPORT_REPLY_NOT_FOUND);
+        }
+    }
+
+    private void isReportReplyDuplicated(Long replyId, String memberNickname) {
+        if (reportReplyRepository.existsByReply_IdAndMember_NicknameAndIsDeleteFalse(replyId, memberNickname)) {
+            throw new DuplicatedException(ResponseStatus.FAIL_REPORT_DUPLICATED);
+        }
+    }
+
+    private ReportReply toEntity(ReportReplyCreateDto dto) {
+        return ReportReply.builder()
+                .member(memberRepository.findByNicknameAndIsDeleteFalse(dto.getMemberNickname()).get())
+                .reply(replyRepository.findByIdAndIsDeleteFalse(dto.getReplyId()).get())
+                .reportCategory(ReportCategory.valueOf(dto.getCategoryName()))
+                .description(dto.getDescription())
+                .isAccept(false)
+                .build();
+    }
+
+    private ReportReplyReadDto toReadDto(ReportReply reportReply) {
+        return ReportReplyReadDto.builder()
+                .reportReplyId(reportReply.getId())
+                .memberNickname(reportReply.getMember().getNickname())
+                .replyId(reportReply.getReply().getId())
+                .replyContent(reportReply.getReply().getContent())
+                .replyWriter(reportReply.getReply().getMember().getNickname())
+                .categoryName(String.valueOf(reportReply.getReportCategory()))
+                .description(reportReply.getDescription())
+                .build();
+    }
+}

--- a/src/main/java/kr/co/imguru/global/model/ResponseStatus.java
+++ b/src/main/java/kr/co/imguru/global/model/ResponseStatus.java
@@ -56,8 +56,9 @@ public enum ResponseStatus {
     FAIL_REVIEW_WRITER_NOT_MATCH("해당 후기의 작성자만이 수정할 수 있습니다.", HttpStatus.BAD_REQUEST),
 
     // Report
-    FAIL_REPORT_NOT_FOUND("클라이언트가 요청한 신고를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
-    FAIL_REPORT_DUPLICATED("클라이언트가 요청한 신고는 이미 접수되었습니다. 중복 신고는 불가능합나디.", HttpStatus.BAD_REQUEST),
+    FAIL_REPORT_POST_NOT_FOUND("클라이언트가 요청한 게시글 신고를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    FAIL_REPORT_REPLY_NOT_FOUND("클라이언트가 요청한 댓글 신고를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    FAIL_REPORT_DUPLICATED("클라이언트가 요청한 신고는 이미 접수되었습니다. 중복 신고는 불가능합니다.", HttpStatus.BAD_REQUEST),
     FAIL_REPORT_CATEGORY_NOT_FOUND("클라이언트가 요청한 신고의 카테고리를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
 
     // Skill


### PR DESCRIPTION
Report의 경우 생성과 조회만 할 수 있어야 한다.

- 신고의 불변성 유지: 수정이나 철회를 허용한다면, 이는 신고한 내용을 언제든지 변경할 수 있다는 의미, 그렇게 되면 신고 시점의 상황이 변형되어 사실과 다른 정보를 제공하는 등 혼란을 초래. 따라서 신고가 접수되고 확인된 후에는 내용을 수정할 수 없도록 하는 것이 일반적.
- 중요한 사안에 대한 신뢰성 유지: 신고는 종종 심각한 문제나 위협을 보고하는 수단. 예를 들어, 범죄 신고, 폭력적인 행동 신고, 사회적으로 민감한 내용 신고 등. 이러한 신고는 신속하고 정확한 조치를 필요로 하며, 이를 위해서는 신고한 내용이 수정되거나 철회되지 않아야 함.
- 남용 방지: 수정이나 철회가 가능하다면, 악의적인 사용자가 신고를 남기고 다른 사람을 괴롭히거나 혼란을 일으킴. 이를 막기 위해 일단 신고가 접수되면 수정이나 철회가 불가능하게 하는 것이 좋은 방법.

1. Report Post CR
2. Report Reply CR
3. 해당 CR을 진행하며 필요한 exception 발생 시의 응답 코드 추가