### PR TITLE
IG-10-jsh/querydsl,queryRefactor

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,11 +45,11 @@ dependencies {
 //    // JSON
 //    implementation 'com.googlecode.json-simple:json-simple:1.1.1'
 //
-//    // QueryDsl
-//    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
-//    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
-//    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
-//    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+    // QueryDsl
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 //
 //    //Security
 //    implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/src/main/java/kr/co/imguru/domain/guru/repository/GuruInfoRepository.java
+++ b/src/main/java/kr/co/imguru/domain/guru/repository/GuruInfoRepository.java
@@ -2,6 +2,7 @@ package kr.co.imguru.domain.guru.repository;
 
 import kr.co.imguru.domain.guru.entity.GuruInfo;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -9,15 +10,6 @@ import java.util.Optional;
 
 @Repository
 public interface GuruInfoRepository extends JpaRepository<GuruInfo, Long> {
-
-    /*
-    select *
-    from guruInfo g, member m
-    where g.member_id = m.id
-    and g.is_delete = false
-    and m.nickname := ?
-     */
-    Optional<GuruInfo> findGuruInfoByMember_NicknameAndIsDeleteFalse(String memberNickname);
 
     List<GuruInfo> findAllByIsDeleteFalse();
 

--- a/src/main/java/kr/co/imguru/domain/guru/repository/GuruInfoSearchRepository.java
+++ b/src/main/java/kr/co/imguru/domain/guru/repository/GuruInfoSearchRepository.java
@@ -1,0 +1,38 @@
+package kr.co.imguru.domain.guru.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import kr.co.imguru.domain.guru.entity.GuruInfo;
+import kr.co.imguru.domain.guru.entity.QGuruInfo;
+import kr.co.imguru.domain.member.entity.QMember;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class GuruInfoSearchRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    private final QGuruInfo guruInfo = QGuruInfo.guruInfo;
+
+    private final QMember member = QMember.member;
+
+    public Optional<GuruInfo> findGuruInfoByMemberNickname(String memberNickname) {
+        GuruInfo temp = queryFactory
+                .selectFrom(guruInfo)
+                .join(member)
+                .on(guruInfo.member.id.eq(member.id))
+                .fetchJoin()
+                .where(
+                        guruInfo.isDelete.eq(Boolean.FALSE),
+                        guruInfo.member.nickname.eq(memberNickname)
+                )
+                .fetchOne();
+
+        return Optional.ofNullable(temp);
+    }
+
+
+}

--- a/src/main/java/kr/co/imguru/domain/guru/service/GuruInfoServiceImpl.java
+++ b/src/main/java/kr/co/imguru/domain/guru/service/GuruInfoServiceImpl.java
@@ -6,6 +6,7 @@ import kr.co.imguru.domain.guru.dto.GuruInfoReadDto;
 import kr.co.imguru.domain.guru.dto.GuruInfoUpdateDto;
 import kr.co.imguru.domain.guru.entity.GuruInfo;
 import kr.co.imguru.domain.guru.repository.GuruInfoRepository;
+import kr.co.imguru.domain.guru.repository.GuruInfoSearchRepository;
 import kr.co.imguru.domain.member.entity.Member;
 import kr.co.imguru.domain.member.repository.MemberRepository;
 import kr.co.imguru.global.common.Role;
@@ -26,6 +27,8 @@ public class GuruInfoServiceImpl implements GuruInfoService {
 
     private final MemberRepository memberRepository;
 
+    private final GuruInfoSearchRepository guruInfoSearchRepository;
+
     @Override
     @Transactional
     public void createGuruInfo(String memberNickname, GuruInfoCreateDto createDto) {
@@ -33,7 +36,7 @@ public class GuruInfoServiceImpl implements GuruInfoService {
 
         isGuruMember(member);
 
-        Optional<GuruInfo> guruInfo = guruRepository.findGuruInfoByMember_NicknameAndIsDeleteFalse(memberNickname);
+        Optional<GuruInfo> guruInfo = guruInfoSearchRepository.findGuruInfoByMemberNickname(memberNickname);
 
         isGuruInfoDuplicated(guruInfo);
 
@@ -45,7 +48,7 @@ public class GuruInfoServiceImpl implements GuruInfoService {
     @Override
     @Transactional
     public GuruInfoReadDto getGuruInfo(String memberNickname) {
-        final Optional<GuruInfo> guruInfo = guruRepository.findGuruInfoByMember_NicknameAndIsDeleteFalse(memberNickname);
+        Optional<GuruInfo> guruInfo = guruInfoSearchRepository.findGuruInfoByMemberNickname(memberNickname);
 
         isGuruInfo(guruInfo);
 
@@ -69,7 +72,7 @@ public class GuruInfoServiceImpl implements GuruInfoService {
         isGuruMember(member);
 
         // 해당 회원이 작성한 전문가 정보가 있는지 확인
-        Optional <GuruInfo> guruInfo = guruRepository.findGuruInfoByMember_NicknameAndIsDeleteFalse(memberNickname);
+        Optional <GuruInfo> guruInfo = guruInfoSearchRepository.findGuruInfoByMemberNickname(memberNickname);
         isGuruInfo(guruInfo);
 
         guruInfo.get().changeGuruInfo(updateDto);
@@ -87,7 +90,7 @@ public class GuruInfoServiceImpl implements GuruInfoService {
         isGuruMember(member);
 
         // 해당 회원이 작성한 전문가 정보가 있는지 확인
-        Optional <GuruInfo> guruInfo = guruRepository.findGuruInfoByMember_NicknameAndIsDeleteFalse(memberNickname);
+        Optional<GuruInfo> guruInfo = guruInfoSearchRepository.findGuruInfoByMemberNickname(memberNickname);
         isGuruInfo(guruInfo);
 
         guruInfo.get().changeDeleteAt();

--- a/src/main/java/kr/co/imguru/domain/post/controller/PostRestController.java
+++ b/src/main/java/kr/co/imguru/domain/post/controller/PostRestController.java
@@ -41,6 +41,11 @@ public class PostRestController {
         return ResponseFormat.successWithData(ResponseStatus.SUCCESS_OK, postService.getAllPosts());
     }
 
+    @GetMapping("/post/wrtier/{memberNickname}")
+    public ResponseFormat<List<PostReadDto>> readPostsByMember(@PathVariable String memberNickname) {
+        return ResponseFormat.successWithData(ResponseStatus.SUCCESS_OK, postService.getPostsByMember(memberNickname));
+    }
+
     @PutMapping("/post/{postId}")
     public ResponseFormat<PostReadDto> updatePost(@PathVariable Long postId,
                                                   @RequestBody @Valid PostUpdateDto updateDto) {

--- a/src/main/java/kr/co/imguru/domain/post/repository/PostSearchRepository.java
+++ b/src/main/java/kr/co/imguru/domain/post/repository/PostSearchRepository.java
@@ -1,0 +1,51 @@
+package kr.co.imguru.domain.post.repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import kr.co.imguru.domain.member.entity.QMember;
+import kr.co.imguru.domain.post.entity.Post;
+import kr.co.imguru.domain.post.entity.QPost;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class PostSearchRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    private final QPost post = QPost.post;
+
+    private final QMember member = QMember.member;
+
+    public List<Post> findPostsByMemberNickname(String memberNickname) {
+        return queryFactory
+                .selectFrom(post)
+                .join(member)
+                .on(post.member.id.eq(member.id))
+                .fetchJoin()
+                .where(
+                        post.isDelete.eq(Boolean.FALSE),
+                        post.member.nickname.eq(memberNickname)
+                )
+                .fetch();
+    }
+
+    private BooleanExpression postSearchText(String searchType, String searchText) {
+        if (!StringUtils.hasText(searchText)) {
+            return null;
+        } else if (searchType.equals("title")) {
+            return post.title.contains(searchText);
+        } else if (searchType.equals("writer")) {
+            return post.member.nickname.contains(searchText);
+        } else if (searchType.equals("guru")){
+            return post.isDelete.eq(Boolean.TRUE);
+        }else {
+            return post.title.contains(searchText).or(post.member.nickname.contains(searchText));
+        }
+    }
+
+}

--- a/src/main/java/kr/co/imguru/domain/post/service/PostService.java
+++ b/src/main/java/kr/co/imguru/domain/post/service/PostService.java
@@ -16,6 +16,8 @@ public interface PostService {
 
     List<PostReadDto> getAllPosts();
 
+    List<PostReadDto> getPostsByMember(String memberNickname);
+
     PostReadDto updatePost(Long postId, PostUpdateDto updateDto);
 
     void deletePost(Long postId);

--- a/src/main/java/kr/co/imguru/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/kr/co/imguru/domain/post/service/PostServiceImpl.java
@@ -8,6 +8,7 @@ import kr.co.imguru.domain.post.dto.PostReadDto;
 import kr.co.imguru.domain.post.dto.PostUpdateDto;
 import kr.co.imguru.domain.post.entity.Post;
 import kr.co.imguru.domain.post.repository.PostRepository;
+import kr.co.imguru.domain.post.repository.PostSearchRepository;
 import kr.co.imguru.global.common.PostCategory;
 import kr.co.imguru.global.common.Role;
 import kr.co.imguru.global.exception.ForbiddenException;
@@ -27,6 +28,8 @@ public class PostServiceImpl implements PostService {
     private final PostRepository postRepository;
 
     private final MemberRepository memberRepository;
+
+    private final PostSearchRepository postSearchRepository;
 
     @Override
     @Transactional
@@ -60,6 +63,14 @@ public class PostServiceImpl implements PostService {
     @Override
     public List<PostReadDto> getAllPosts() {
         return postRepository.findAllByIsDeleteFalse()
+                .stream()
+                .map(this::toReadDto)
+                .toList();
+    }
+
+    @Override
+    public List<PostReadDto> getPostsByMember(String memberNickname) {
+        return postSearchRepository.findPostsByMemberNickname(memberNickname)
                 .stream()
                 .map(this::toReadDto)
                 .toList();

--- a/src/main/java/kr/co/imguru/domain/reply/repository/ReplyRepository.java
+++ b/src/main/java/kr/co/imguru/domain/reply/repository/ReplyRepository.java
@@ -2,6 +2,7 @@ package kr.co.imguru.domain.reply.repository;
 
 import kr.co.imguru.domain.reply.entity.Reply;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -11,10 +12,6 @@ import java.util.Optional;
 public interface ReplyRepository extends JpaRepository<Reply, Long> {
 
     Optional<Reply> findByIdAndIsDeleteFalse(Long id);
-
-    List<Reply> findAllByPost_IdAndIsDeleteFalse(Long postId);
-
-    List<Reply> findAllByMember_NicknameAndIsDeleteFalse(String memberNickname);
 
     List<Reply> findAllByIsDeleteFalse();
 

--- a/src/main/java/kr/co/imguru/domain/reply/repository/ReplySearchRepository.java
+++ b/src/main/java/kr/co/imguru/domain/reply/repository/ReplySearchRepository.java
@@ -1,0 +1,52 @@
+package kr.co.imguru.domain.reply.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import kr.co.imguru.domain.member.entity.QMember;
+import kr.co.imguru.domain.post.entity.QPost;
+import kr.co.imguru.domain.reply.entity.QReply;
+import kr.co.imguru.domain.reply.entity.Reply;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class ReplySearchRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    private QReply reply = QReply.reply;
+
+    private QMember member = QMember.member;
+
+    private QPost post = QPost.post;
+
+    public List<Reply> findRepliesByMemberNickname(String memberNickname) {
+        return queryFactory
+                .selectFrom(reply)
+                .join(member)
+                .on(reply.member.id.eq(member.id))
+                .fetchJoin()
+                .where(
+                        reply.isDelete.eq(Boolean.FALSE),
+                        reply.member.nickname.eq(memberNickname)
+                )
+                .fetch();
+    }
+
+    public List<Reply> findRepliesByPostId(Long postId) {
+        return queryFactory
+                .selectFrom(reply)
+                .join(post)
+                .on(reply.post.id.eq(post.id))
+                .fetchJoin()
+                .where(
+                        reply.isDelete.eq(Boolean.FALSE),
+                        reply.post.id.eq(postId)
+                )
+                .fetch();
+    }
+
+
+}

--- a/src/main/java/kr/co/imguru/domain/reply/service/ReplyServiceImpl.java
+++ b/src/main/java/kr/co/imguru/domain/reply/service/ReplyServiceImpl.java
@@ -10,6 +10,7 @@ import kr.co.imguru.domain.reply.dto.ReplyReadDto;
 import kr.co.imguru.domain.reply.dto.ReplyUpdateDto;
 import kr.co.imguru.domain.reply.entity.Reply;
 import kr.co.imguru.domain.reply.repository.ReplyRepository;
+import kr.co.imguru.domain.reply.repository.ReplySearchRepository;
 import kr.co.imguru.global.exception.ForbiddenException;
 import kr.co.imguru.global.exception.NotFoundException;
 import kr.co.imguru.global.model.ResponseStatus;
@@ -28,6 +29,8 @@ public class ReplyServiceImpl implements ReplyService {
     private final MemberRepository memberRepository;
 
     private final PostRepository postRepository;
+
+    private final ReplySearchRepository replySearchRepository;
 
     //Create
     @Override
@@ -57,7 +60,7 @@ public class ReplyServiceImpl implements ReplyService {
         Optional<Post> post = postRepository.findByIdAndIsDeleteFalse(postId);
         isPost(post);
 
-        return replyRepository.findAllByPost_IdAndIsDeleteFalse(postId)
+        return replySearchRepository.findRepliesByPostId(postId)
                 .stream()
                 .map(this::toReadDto)
                 .toList();
@@ -68,7 +71,7 @@ public class ReplyServiceImpl implements ReplyService {
         Optional<Member> member = memberRepository.findByNicknameAndIsDeleteFalse(memberNickname);
         isMember(member);
 
-        return replyRepository.findAllByMember_NicknameAndIsDeleteFalse(memberNickname)
+        return replySearchRepository.findRepliesByMemberNickname(memberNickname)
                 .stream()
                 .map(this::toReadDto)
                 .toList();

--- a/src/main/java/kr/co/imguru/domain/report/repository/ReportPostRepository.java
+++ b/src/main/java/kr/co/imguru/domain/report/repository/ReportPostRepository.java
@@ -4,14 +4,8 @@ import kr.co.imguru.domain.report.entity.ReportPost;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
-
 @Repository
 public interface ReportPostRepository extends JpaRepository<ReportPost, Long> {
 
-    boolean existsByPost_IdAndMember_NicknameAndIsDeleteFalse(Long postId, String memberNickname);
 
-    List<ReportPost> findAllByPost_Id(Long postId);
-
-    List<ReportPost> findAllByMember_Nickname(String memberNickname);
 }

--- a/src/main/java/kr/co/imguru/domain/report/repository/ReportPostSearchRepository.java
+++ b/src/main/java/kr/co/imguru/domain/report/repository/ReportPostSearchRepository.java
@@ -1,0 +1,68 @@
+package kr.co.imguru.domain.report.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import kr.co.imguru.domain.member.entity.QMember;
+import kr.co.imguru.domain.post.entity.QPost;
+import kr.co.imguru.domain.report.entity.QReportPost;
+import kr.co.imguru.domain.report.entity.ReportPost;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class ReportPostSearchRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    private QReportPost reportPost = QReportPost.reportPost;
+
+    private QMember member = QMember.member;
+
+    private QPost post = QPost.post;
+
+    public List<ReportPost> findReportPostsByMemberNickname(String memberNickname) {
+        return queryFactory
+                .selectFrom(reportPost)
+                .join(member)
+                .on(reportPost.member.id.eq(member.id))
+                .fetchJoin()
+                .where(
+                        reportPost.isDelete.eq(Boolean.FALSE),
+                        reportPost.member.nickname.eq(memberNickname)
+                )
+                .fetch();
+    }
+
+    public List<ReportPost> findReportPostsByPostId(Long postId) {
+        return queryFactory
+                .selectFrom(reportPost)
+                .join(post)
+                .on(reportPost.post.id.eq(post.id))
+                .fetchJoin()
+                .where(
+                        reportPost.isDelete.eq(Boolean.FALSE),
+                        reportPost.post.id.eq(postId)
+                )
+                .fetch();
+    }
+
+    public ReportPost existsByPostIdAndMemberNickname(Long postId, String memberNickname) {
+        return queryFactory
+                .selectFrom(reportPost)
+                .join(member)
+                .on(reportPost.member.id.eq(member.id))
+                .fetchJoin()
+                .join(post)
+                .on(reportPost.post.id.eq(post.id))
+                .fetchJoin()
+                .where(
+                        reportPost.isDelete.eq(Boolean.FALSE),
+                        reportPost.member.nickname.eq(memberNickname),
+                        reportPost.post.id.eq(postId)
+                )
+                .fetchOne();
+    }
+
+}

--- a/src/main/java/kr/co/imguru/domain/report/repository/ReportReplyRepository.java
+++ b/src/main/java/kr/co/imguru/domain/report/repository/ReportReplyRepository.java
@@ -4,14 +4,7 @@ import kr.co.imguru.domain.report.entity.ReportReply;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
-
 @Repository
 public interface ReportReplyRepository extends JpaRepository<ReportReply, Long> {
 
-    boolean existsByReply_IdAndMember_NicknameAndIsDeleteFalse(Long replyId, String memberNickname);
-
-    List<ReportReply> findAllByReply_Id(Long replyId);
-
-    List<ReportReply> findAllByMember_Nickname(String memberNickname);
 }

--- a/src/main/java/kr/co/imguru/domain/report/repository/ReportReplySearchRepository.java
+++ b/src/main/java/kr/co/imguru/domain/report/repository/ReportReplySearchRepository.java
@@ -1,0 +1,67 @@
+package kr.co.imguru.domain.report.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import kr.co.imguru.domain.member.entity.QMember;
+import kr.co.imguru.domain.reply.entity.QReply;
+import kr.co.imguru.domain.report.entity.QReportReply;
+import kr.co.imguru.domain.report.entity.ReportReply;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class ReportReplySearchRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    private QReportReply reportReply = QReportReply.reportReply;
+
+    private QMember member = QMember.member;
+
+    private QReply reply = QReply.reply;
+
+    public List<ReportReply> findReportRepliesByMemberNickname(String memberNickname) {
+        return queryFactory
+                .selectFrom(reportReply)
+                .join(member)
+                .on(reportReply.member.id.eq(member.id))
+                .fetchJoin()
+                .where(
+                        reportReply.isDelete.eq(Boolean.FALSE),
+                        reportReply.member.nickname.eq(memberNickname)
+                )
+                .fetch();
+    }
+
+    public List<ReportReply> findReportRepliesByReplyId(Long replyId) {
+        return queryFactory
+                .selectFrom(reportReply)
+                .join(reply)
+                .on(reportReply.reply.id.eq(reply.id))
+                .fetchJoin()
+                .where(
+                        reportReply.isDelete.eq(Boolean.FALSE),
+                        reportReply.reply.id.eq(replyId)
+                )
+                .fetch();
+    }
+
+    public ReportReply existsByReplyIdAndMemberNickname(Long replyId, String memberNickname) {
+        return queryFactory
+                .selectFrom(reportReply)
+                .join(member)
+                .on(reportReply.member.id.eq(member.id))
+                .fetchJoin()
+                .join(reply)
+                .on(reportReply.reply.id.eq(reply.id))
+                .fetchJoin()
+                .where(
+                        reportReply.isDelete.eq(Boolean.FALSE),
+                        reportReply.member.nickname.eq(memberNickname),
+                        reportReply.reply.id.eq(replyId)
+                )
+                .fetchOne();
+    }
+}

--- a/src/main/java/kr/co/imguru/domain/report/service/ReportPostServiceImpl.java
+++ b/src/main/java/kr/co/imguru/domain/report/service/ReportPostServiceImpl.java
@@ -1,5 +1,6 @@
 package kr.co.imguru.domain.report.service;
 
+import kr.co.imguru.domain.guru.entity.GuruInfo;
 import kr.co.imguru.domain.member.entity.Member;
 import kr.co.imguru.domain.member.repository.MemberRepository;
 import kr.co.imguru.domain.post.entity.Post;
@@ -8,6 +9,7 @@ import kr.co.imguru.domain.report.dto.ReportPostCreateDto;
 import kr.co.imguru.domain.report.dto.ReportPostReadDto;
 import kr.co.imguru.domain.report.entity.ReportPost;
 import kr.co.imguru.domain.report.repository.ReportPostRepository;
+import kr.co.imguru.domain.report.repository.ReportPostSearchRepository;
 import kr.co.imguru.global.common.ReportCategory;
 import kr.co.imguru.global.exception.DuplicatedException;
 import kr.co.imguru.global.exception.IllegalArgumentException;
@@ -28,6 +30,8 @@ public class ReportPostServiceImpl implements ReportPostService {
     private final MemberRepository memberRepository;
 
     private final PostRepository postRepository;
+
+    private final ReportPostSearchRepository reportPostSearchRepository;
 
     @Override
     public void createReportPost(ReportPostCreateDto createDto) {
@@ -55,7 +59,7 @@ public class ReportPostServiceImpl implements ReportPostService {
 
     @Override
     public List<ReportPostReadDto> getReportPostByPost(Long postId) {
-        return reportPostRepository.findAllByPost_Id(postId)
+        return reportPostSearchRepository.findReportPostsByPostId(postId)
                 .stream()
                 .map(this::toReadDto)
                 .toList();
@@ -63,7 +67,7 @@ public class ReportPostServiceImpl implements ReportPostService {
 
     @Override
     public List<ReportPostReadDto> getReportPostByMember(String memberNickname) {
-        return reportPostRepository.findAllByMember_Nickname(memberNickname)
+        return reportPostSearchRepository.findReportPostsByMemberNickname(memberNickname)
                 .stream()
                 .map(this::toReadDto)
                 .toList();
@@ -104,7 +108,9 @@ public class ReportPostServiceImpl implements ReportPostService {
     }
 
     private void isReportPostDuplicated(Long postId, String memberNickname) {
-        if (reportPostRepository.existsByPost_IdAndMember_NicknameAndIsDeleteFalse(postId, memberNickname)) {
+        Optional<ReportPost> reportPost = Optional.ofNullable(reportPostSearchRepository.existsByPostIdAndMemberNickname(postId, memberNickname));
+
+        if (reportPost.isPresent()) {
             throw new DuplicatedException(ResponseStatus.FAIL_REPORT_DUPLICATED);
         }
     }

--- a/src/main/java/kr/co/imguru/domain/report/service/ReportReplyServiceImpl.java
+++ b/src/main/java/kr/co/imguru/domain/report/service/ReportReplyServiceImpl.java
@@ -4,10 +4,13 @@ import kr.co.imguru.domain.member.entity.Member;
 import kr.co.imguru.domain.member.repository.MemberRepository;
 import kr.co.imguru.domain.reply.entity.Reply;
 import kr.co.imguru.domain.reply.repository.ReplyRepository;
+import kr.co.imguru.domain.reply.repository.ReplySearchRepository;
 import kr.co.imguru.domain.report.dto.ReportReplyCreateDto;
 import kr.co.imguru.domain.report.dto.ReportReplyReadDto;
+import kr.co.imguru.domain.report.entity.ReportPost;
 import kr.co.imguru.domain.report.entity.ReportReply;
 import kr.co.imguru.domain.report.repository.ReportReplyRepository;
+import kr.co.imguru.domain.report.repository.ReportReplySearchRepository;
 import kr.co.imguru.global.common.ReportCategory;
 import kr.co.imguru.global.exception.DuplicatedException;
 import kr.co.imguru.global.exception.IllegalArgumentException;
@@ -28,6 +31,8 @@ public class ReportReplyServiceImpl implements ReportReplyService {
     private final MemberRepository memberRepository;
 
     private final ReplyRepository replyRepository;
+
+    private final ReportReplySearchRepository reportReplySearchRepository;
 
     @Override
     public void createReportReply(ReportReplyCreateDto createDto) {
@@ -55,7 +60,7 @@ public class ReportReplyServiceImpl implements ReportReplyService {
 
     @Override
     public List<ReportReplyReadDto> getReportRepliesByReply(Long replyId) {
-        return reportReplyRepository.findAllByReply_Id(replyId)
+        return reportReplySearchRepository.findReportRepliesByReplyId(replyId)
                 .stream()
                 .map(this::toReadDto)
                 .toList();
@@ -63,7 +68,7 @@ public class ReportReplyServiceImpl implements ReportReplyService {
 
     @Override
     public List<ReportReplyReadDto> getReportRepliesByMember(String memberNickname) {
-        return reportReplyRepository.findAllByMember_Nickname(memberNickname)
+        return reportReplySearchRepository.findReportRepliesByMemberNickname(memberNickname)
                 .stream()
                 .map(this::toReadDto)
                 .toList();
@@ -104,7 +109,9 @@ public class ReportReplyServiceImpl implements ReportReplyService {
     }
 
     private void isReportReplyDuplicated(Long replyId, String memberNickname) {
-        if (reportReplyRepository.existsByReply_IdAndMember_NicknameAndIsDeleteFalse(replyId, memberNickname)) {
+        Optional<ReportReply> reportReply = Optional.ofNullable(reportReplySearchRepository.existsByReplyIdAndMemberNickname(replyId, memberNickname));
+
+        if (reportReply.isPresent()) {
             throw new DuplicatedException(ResponseStatus.FAIL_REPORT_DUPLICATED);
         }
     }

--- a/src/main/java/kr/co/imguru/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/kr/co/imguru/domain/review/repository/ReviewRepository.java
@@ -2,6 +2,7 @@ package kr.co.imguru.domain.review.repository;
 
 import kr.co.imguru.domain.review.entity.Review;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -13,8 +14,4 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     Optional<Review> findByIdAndIsDeleteFalse(Long id);
 
     List<Review> findAllByIsDeleteFalse();
-
-    List<Review> findAllByUser_NicknameAndIsDeleteFalse(String userNickname);
-
-    List<Review> findAllByGuru_NicknameAndIsDeleteFalse(String guruNickname);
 }

--- a/src/main/java/kr/co/imguru/domain/review/repository/ReviewSearchRepository.java
+++ b/src/main/java/kr/co/imguru/domain/review/repository/ReviewSearchRepository.java
@@ -1,0 +1,49 @@
+package kr.co.imguru.domain.review.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import kr.co.imguru.domain.member.entity.QMember;
+import kr.co.imguru.domain.review.entity.QReview;
+import kr.co.imguru.domain.review.entity.Review;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class ReviewSearchRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    private QReview review = QReview.review;
+
+    private QMember member = QMember.member;
+
+    public List<Review> findReviewsByUserNickname(String userNickname) {
+        return queryFactory
+                .selectFrom(review)
+                .join(member)
+                .on(review.user.id.eq(member.id))
+                .fetchJoin()
+                .where(
+                        review.isDelete.eq(Boolean.FALSE),
+                        review.user.nickname.eq(userNickname)
+                )
+                .fetch();
+    }
+
+    public List<Review> findReviewsByGuruNickname(String guruNickname) {
+        return queryFactory
+                .selectFrom(review)
+                .join(member)
+                .on(review.guru.id.eq(member.id))
+                .fetchJoin()
+                .where(
+                        review.isDelete.eq(Boolean.FALSE),
+                        review.guru.nickname.eq(guruNickname)
+                )
+                .fetch();
+    }
+
+
+}

--- a/src/main/java/kr/co/imguru/domain/review/service/ReviewServiceImpl.java
+++ b/src/main/java/kr/co/imguru/domain/review/service/ReviewServiceImpl.java
@@ -8,6 +8,7 @@ import kr.co.imguru.domain.review.dto.ReviewReadDto;
 import kr.co.imguru.domain.review.dto.ReviewUpdateDto;
 import kr.co.imguru.domain.review.entity.Review;
 import kr.co.imguru.domain.review.repository.ReviewRepository;
+import kr.co.imguru.domain.review.repository.ReviewSearchRepository;
 import kr.co.imguru.global.exception.ForbiddenException;
 import kr.co.imguru.global.exception.InvalidRequestException;
 import kr.co.imguru.global.exception.NotFoundException;
@@ -25,6 +26,8 @@ public class ReviewServiceImpl implements ReviewService {
     private final ReviewRepository reviewRepository;
 
     private final MemberRepository memberRepository;
+
+    private final ReviewSearchRepository reviewSearchRepository;
 
     @Override
     @Transactional
@@ -51,7 +54,7 @@ public class ReviewServiceImpl implements ReviewService {
 
     @Override
     public List<ReviewReadDto> getReviewsByGuru(String guruNickname) {
-        return reviewRepository.findAllByGuru_NicknameAndIsDeleteFalse(guruNickname)
+        return reviewSearchRepository.findReviewsByGuruNickname(guruNickname)
                 .stream()
                 .map(this::toReadDto)
                 .toList();
@@ -59,7 +62,7 @@ public class ReviewServiceImpl implements ReviewService {
 
     @Override
     public List<ReviewReadDto> getReviewsByUser(String userNickname) {
-        return reviewRepository.findAllByUser_NicknameAndIsDeleteFalse(userNickname)
+        return reviewSearchRepository.findReviewsByUserNickname(userNickname)
                 .stream()
                 .map(this::toReadDto)
                 .toList();

--- a/src/main/java/kr/co/imguru/global/config/QueryDslConfig.java
+++ b/src/main/java/kr/co/imguru/global/config/QueryDslConfig.java
@@ -1,0 +1,20 @@
+package kr.co.imguru.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+
+}


### PR DESCRIPTION
1. QueryDsl 사용 위한 dependency 추가
2. QueyrDslConfig 클래스 생성 후, JPAQueryFactory DI
3. 기존의 Repository와 SearchRepository 의 차이는 QueryDsl의 사용 유무
 -> 현재 모든 설계가 fetch 조건이 Lazy로 되어 있어서 join이 필요한 경우 query가 각각 실행되는 문제가 있다. 해당 문제를 해결해주기 위해서는 query문 실행 시, fetch 조건을 Fetch로 수정해줘야 한다. 그렇기에 SearchRepository에 join이 필요한 쿼리의 경우 적용해주기로 결정